### PR TITLE
Updated nodesource installation url

### DIFF
--- a/packer-templates/scripts/application.sh
+++ b/packer-templates/scripts/application.sh
@@ -12,7 +12,7 @@ apt-get remove --purge node
 
 # application and build process required packages
 # add Node.js maintained repositories
-curl -sL https://deb.nodesource.com/setup | bash -
+curl -sL https://deb.nodesource.com/setup_4.x | bash -
 
 # for tests and build
 apt-get -y install nodejs


### PR DESCRIPTION
As per the following warning observed during a packer build :

```
virtualbox-iso: You should use the script that corresponds to the version of Node.js you
virtualbox-iso: wish to install. e.g.
virtualbox-iso:
virtualbox-iso: * https://deb.nodesource.com/setup_4.x — Node.js v4 LTS "Argon" (recommended)
virtualbox-iso: * https://deb.nodesource.com/setup_6.x — Node.js v6 Current
virtualbox-iso:
virtualbox-iso: Please see https://github.com/nodejs/LTS/ for details about which version
virtualbox-iso: may be appropriate for you.
virtualbox-iso:
virtualbox-iso: The NodeSource Node.js Linux distributions GitHub repository contains
virtualbox-iso: information about which versions of Node.js and which Linux distributions
virtualbox-iso: are supported and how to use the install scripts.
virtualbox-iso: https://github.com/nodesource/distributions
```

I have updated the script application.sh so that the curl is executed against the updated url.
