### PR TITLE
Fix Jenkins install on Amazon AMI. Fix Ubuntu ISO version.

### DIFF
--- a/packer-templates/application-server.json
+++ b/packer-templates/application-server.json
@@ -1,7 +1,7 @@
 {
   "variables": {
       "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.4-server-amd64",
+      "PACKER_BOX_NAME": "ubuntu-14.04.5-server-amd64",
       "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
       "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
       "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
@@ -39,7 +39,7 @@
         "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
         "guest_os_type": "Ubuntu_64",
         "http_directory": "http",
-        "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+        "iso_checksum": "dde07d37647a1d2d9247e33f14e91acb10445a97578384896b4e1d985f754cc1",
         "iso_checksum_type": "sha256",
         "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
         "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",

--- a/packer-templates/control-server.json
+++ b/packer-templates/control-server.json
@@ -1,7 +1,7 @@
 {
   "variables": {
       "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.4-server-amd64",
+      "PACKER_BOX_NAME": "ubuntu-14.04.5-server-amd64",
       "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
       "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
       "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
@@ -39,7 +39,7 @@
         "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
         "guest_os_type": "Ubuntu_64",
         "http_directory": "http",
-        "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+        "iso_checksum": "dde07d37647a1d2d9247e33f14e91acb10445a97578384896b4e1d985f754cc1",
         "iso_checksum_type": "sha256",
         "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
         "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
@@ -60,8 +60,8 @@
         "access_key": "{{ user `AWS_ACCESS_KEY_ID` }}",
         "secret_key": "{{ user `AWS_SECRET_ACCESS_KEY` }}",
         "region": "us-east-1",
-        "source_ami": "ami-10b68a78",
-        "instance_type": "t1.micro",
+        "source_ami": "ami-772aa961",
+        "instance_type": "t2.micro",
         "ssh_username": "ubuntu",
         "ami_name": "control-{{ user `PACKER_BOX_NAME` }}-{{timestamp}}"
       },

--- a/packer-templates/scripts/jenkins.sh
+++ b/packer-templates/scripts/jenkins.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -eux
 
 # JDK and JRE are required for Jenkins
-apt-get install -y openjdk-7-jre openjdk-7-jdk unzip dos2unix
+add-apt-repository ppa:openjdk-r/ppa
+apt-get update
+apt-get install openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk
 
 wget -q -O - https://jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add -
 echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list

--- a/packer-templates/scripts/jenkins.sh
+++ b/packer-templates/scripts/jenkins.sh
@@ -3,7 +3,7 @@
 # JDK and JRE are required for Jenkins
 add-apt-repository ppa:openjdk-r/ppa
 apt-get update
-apt-get install openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk
+apt-get install -y openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk
 
 wget -q -O - https://jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add -
 echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list


### PR DESCRIPTION
The provided `packer-templates/application-server.json`, `packer-templates/control-server.json`, and `packer-templates/scripts/jenkins.sh` files all required modifications for me to properly deploy the Virtualbox and AWS Cloud AMI environments.

Changes include: 

1. Updating the Ubuntu ISO version (and its associated checksum) to 14.04.5, as 14.04.4 no longer works.
2. Updating the `amazon-ebs` builder to use an AMI that's supported on AWS free tier accounts.
3. Updating the jenkins.sh script to fix the Java install after viewing an issue with Java 7 and Jenkins here: https://issues.jenkins-ci.org/browse/JENKINS-43495?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&showAll=true
