### PR TITLE
Fix: update iso link and checksum from 14.04.4 to 14.04.5

### DIFF
--- a/packer-templates/application-server.json
+++ b/packer-templates/application-server.json
@@ -1,7 +1,7 @@
 {
   "variables": {
       "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.4-server-amd64",
+      "PACKER_BOX_NAME": "ubuntu-14.04.5-server-amd64",
       "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
       "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
       "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
@@ -39,7 +39,7 @@
         "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
         "guest_os_type": "Ubuntu_64",
         "http_directory": "http",
-        "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+	"iso_checksum": "dde07d37647a1d2d9247e33f14e91acb10445a97578384896b4e1d985f754cc1",
         "iso_checksum_type": "sha256",
         "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
         "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",


### PR DESCRIPTION
Current instructions that asks student to"retry the command until the ISO download succeeds" has become misleading because the ISO no longer downloads due to a "broken link" rather than "checksum mismatch". Please update link and checksum to resolve issue.

http://releases.ubuntu.com/trusty/ubuntu-14.04.4-server-amd64.iso <-- BROKEN
http://releases.ubuntu.com/trusty/ubuntu-14.04.5-server-amd64.iso <-- WORKING

Orwa.
Udacity student