### PR TITLE
	Update PACKER_BOX_NAME and iso_checksum for Ubuntu 14.04.5

### DIFF
--- a/packer-templates/application-server.json
+++ b/packer-templates/application-server.json
@@ -1,7 +1,7 @@
 {
   "variables": {
       "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.4-server-amd64",
+      "PACKER_BOX_NAME": "ubuntu-14.04.5-server-amd64",
       "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
       "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
       "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
@@ -39,7 +39,7 @@
         "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
         "guest_os_type": "Ubuntu_64",
         "http_directory": "http",
-        "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+        "iso_checksum": "dde07d37647a1d2d9247e33f14e91acb10445a97578384896b4e1d985f754cc1",
         "iso_checksum_type": "sha256",
         "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
         "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",

--- a/packer-templates/control-server.json
+++ b/packer-templates/control-server.json
@@ -1,7 +1,7 @@
 {
   "variables": {
       "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.4-server-amd64",
+      "PACKER_BOX_NAME": "ubuntu-14.04.5-server-amd64",
       "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
       "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
       "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
@@ -39,7 +39,7 @@
         "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
         "guest_os_type": "Ubuntu_64",
         "http_directory": "http",
-        "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+        "iso_checksum": "dde07d37647a1d2d9247e33f14e91acb10445a97578384896b4e1d985f754cc1",
         "iso_checksum_type": "sha256",
         "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
         "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",


### PR DESCRIPTION
Ubuntu released 14.04.5 and made 14.04.4 unavailable which causes Packer's download to fail. This updates the Packer templates to use 14.04.5 by changing PACKER_BOX_NAME and iso_checksum. Checksum provided by http://releases.ubuntu.com/trusty/SHA256SUMS.