### PR TITLE
Update application-server, Readme, graphite.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Build 'virtualbox-iso' errored: ISO download failed.
 ```
 
 * Run `cd virtualbox`
-* Run `vagrant box add ubuntu-14.04.4-server-amd64-appserver_virtualbox.box --name devops-appserver`
+* Run `vagrant box add devops-appserver ubuntu-14.04.5-server-amd64-appserver_virtualbox.box`
 * Run `vagrant up`
 * Run `vagrant ssh` to connect to the server
 

--- a/packer-templates/application-server.json
+++ b/packer-templates/application-server.json
@@ -1,7 +1,7 @@
 {
   "variables": {
       "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.4-server-amd64",
+      "PACKER_BOX_NAME": "ubuntu-14.04.5-server-amd64",
       "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
       "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
       "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
@@ -39,7 +39,7 @@
         "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
         "guest_os_type": "Ubuntu_64",
         "http_directory": "http",
-        "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+        "iso_checksum": "dde07d37647a1d2d9247e33f14e91acb10445a97578384896b4e1d985f754cc1",
         "iso_checksum_type": "sha256",
         "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
         "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",

--- a/packer-templates/scripts/graphite.sh
+++ b/packer-templates/scripts/graphite.sh
@@ -3,7 +3,7 @@
 apt-get -y install uwsgi-plugin-python uwsgi
 
 # reqs for Graphite
-apt-get -y install python-dev
+apt-get -y install build-essential libssl-dev libffi-dev python-dev
 apt-get -y install python-django python-django-tagging python-cairo
 apt-get -y install python-pip
 pip install pytz


### PR DESCRIPTION
The ubuntu-14.04.4-server-amd64 image does no longer exist
at Trusty repo, so PACKER_BOX_NAME's value is updated along
with the iso_checksum's value.

Also, the 'vagrant box add' command shown in ReadMe has
slightly different syntax at the moment, so, its current
version fails with syntax error. The 'name' parameter moved
to its expected location will resolve it.