### PR TITLE
updated jdk/jre version from 7 to 8

### DIFF
--- a/packer-templates/scripts/jenkins.sh
+++ b/packer-templates/scripts/jenkins.sh
@@ -1,7 +1,9 @@
 #!/bin/bash -eux
 
 # JDK and JRE are required for Jenkins
-apt-get install -y openjdk-7-jre openjdk-7-jdk unzip dos2unix
+add-apt-repository ppa:openjdk-r/ppa
+apt-get update
+apt-get install -y openjdk-8-jre openjdk-8-jre-headless openjdk-8-jdk
 
 wget -q -O - https://jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add -
 echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list


### PR DESCRIPTION
Java 7 made unable to deploy jenkins onto Google Cloud/AWS for some people. #8