### PR TITLE
Update images to Ubuntu 18.04 for all builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Build 'virtualbox-iso' errored: ISO download failed.
 ```
 
 * Run `cd virtualbox`
-* Run `vagrant box add ubuntu-14.04.4-server-amd64-appserver_virtualbox.box --name devops-appserver`
+* Run `vagrant box add ubuntu-18.04.1-server-amd64-appserver_virtualbox.box --name devops-appserver`
 * Run `vagrant up`
 * Run `vagrant ssh` to connect to the server
 

--- a/packer-templates/application-server.json
+++ b/packer-templates/application-server.json
@@ -1,7 +1,7 @@
 {
   "variables": {
       "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.4-server-amd64",
+      "PACKER_BOX_NAME": "ubuntu-18.04.1-server-amd64",
       "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
       "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
       "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
@@ -39,9 +39,9 @@
         "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
         "guest_os_type": "Ubuntu_64",
         "http_directory": "http",
-        "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+        "iso_checksum": "a5b0ea5918f850124f3d72ef4b85bda82f0fcd02ec721be19c1a6952791c8ee8",
         "iso_checksum_type": "sha256",
-        "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
+        "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/bionic/release/{{ user `PACKER_BOX_NAME` }}.iso",
         "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
         "ssh_password": "vagrant",
         "ssh_port": 22,
@@ -60,7 +60,7 @@
         "access_key": "{{ user `AWS_ACCESS_KEY_ID` }}",
         "secret_key": "{{ user `AWS_SECRET_ACCESS_KEY` }}",
         "region": "us-east-1",
-        "source_ami": "ami-10b68a78",
+        "source_ami": "ami-0ac019f4fcb7cb7e6s",
         "instance_type": "t1.micro",
         "ssh_username": "ubuntu",
         "ami_name": "packer-app-server {{timestamp}}"
@@ -69,16 +69,16 @@
         "type": "googlecompute",
         "account_file": "account.json",
         "project_id": "devops-intro-project",
-        "source_image": "ubuntu-1404-trusty-v20150316",
+        "source_image": "ubuntu-1804-bionic-v20181222",
         "zone": "us-central1-a",
-        "image_name": "application-ubuntu-1404-{{timestamp}}",
+        "image_name": "application-ubuntu-1804-{{timestamp}}",
         "machine_type": "n1-standard-1",
         "ssh_username": "ubuntu"
       },
       {
         "type": "digitalocean",
         "api_token": "{{ user `DIGITALOCEAN_API_TOKEN` }}",
-        "image": "ubuntu-14-04-x64",
+        "image": "ubuntu-18.04.1-live-server-amd64",
         "region": "tor1",
         "size": "512mb",
         "droplet_name": "udacity-devops",

--- a/packer-templates/control-server.json
+++ b/packer-templates/control-server.json
@@ -1,7 +1,7 @@
 {
   "variables": {
       "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.4-server-amd64",
+      "PACKER_BOX_NAME": "ubuntu-18.04.1-server-amd64",
       "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
       "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
       "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
@@ -39,9 +39,9 @@
         "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
         "guest_os_type": "Ubuntu_64",
         "http_directory": "http",
-        "iso_checksum": "07e4bb5569814eab41fafac882ba127893e3ff0bdb7ec931c9b2d040e3e94e7a",
+         "iso_checksum": "a5b0ea5918f850124f3d72ef4b85bda82f0fcd02ec721be19c1a6952791c8ee8",
         "iso_checksum_type": "sha256",
-        "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
+        "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/bionic/release/{{ user `PACKER_BOX_NAME` }}.iso",
         "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
         "ssh_password": "vagrant",
         "ssh_port": 22,
@@ -69,7 +69,7 @@
         "type": "googlecompute",
         "account_file": "account.json",
         "project_id": "devops-intro-project",
-        "source_image": "ubuntu-1404-trusty-v20150316",
+        "source_image": "ubuntu-1804-bionic-v20181222",
         "zone": "us-central1-a",
         "image_name": "control-ubuntu-1404-{{timestamp}}",
         "machine_type": "n1-standard-1",
@@ -78,7 +78,7 @@
       {
       "type": "digitalocean",
       "api_token": "{{ user `DIGITALOCEAN_API_TOKEN` }}",
-      "image": "ubuntu-14-04-x64",
+      "image": "ubuntu-18.04.1-live-server-amd64",
       "region": "tor1",
       "size": "512mb",
       "droplet_name": "udacity-devops",


### PR DESCRIPTION
Update images to Ubuntu 18.04 for all builders:
- virtualboxiso
- amazon-ebs
- googlecompute
- digitalocean

to avoid the error of that nonexistent isos:

![screenshot from 2019-01-24 23-53-19](https://user-images.githubusercontent.com/9141708/51720092-53a11f80-2033-11e9-8c57-774b4e37b0e4.png)

With the 18.04 iso, everything is working fine.
