### PR TITLE
chore: remove duplicate attribute type under builders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 packer_cache
 packer-templates/virtualbox/
 devops-kungfu/
+output/

--- a/packer-templates/application-server.json
+++ b/packer-templates/application-server.json
@@ -47,7 +47,6 @@
         "ssh_port": 22,
         "ssh_username": "vagrant",
         "ssh_wait_timeout": "10000s",
-        "type": "virtualbox-iso",
         "vm_name": "{{ user `PACKER_BOX_NAME` }}",
         "vboxmanage": [
           ["modifyvm", "{{.Name}}", "--memory", "1024"],

--- a/packer-templates/application-server.json
+++ b/packer-templates/application-server.json
@@ -1,92 +1,90 @@
 {
   "variables": {
-      "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.6-server-amd64",
-      "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
-      "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-      "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
+    "PACKER_OS_FLAVOUR": "ubuntu",
+    "PACKER_BOX_NAME": "ubuntu-14.04.6-server-amd64",
+    "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
+  },
+  "builders": [{
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US<wait>",
+        " netcfg/get_domain=vm<wait>",
+        " netcfg/get_hostname=vagrant<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "headless": false,
+      "disk_size": 10140,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "Ubuntu_64",
+      "http_directory": "http",
+      "iso_checksum": "b17d7c1e9d0321ad5810ba77b69aef43f0f29a5422b08120e6ee0576c4527c0e",
+      "iso_checksum_type": "sha256",
+      "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vm_name": "{{ user `PACKER_BOX_NAME` }}",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--memory", "1024"],
+        ["modifyvm", "{{.Name}}", "--cpus", "2"]
+      ],
+      "virtualbox_version_file": ".vbox_version"
     },
-    "builders": [
-      {
-        "type": "virtualbox-iso",
-        "boot_command": [
-          "<esc><wait>",
-          "<esc><wait>",
-          "<enter><wait>",
-          "/install/vmlinuz<wait>",
-          " auto<wait>",
-          " console-setup/ask_detect=false<wait>",
-          " console-setup/layoutcode=us<wait>",
-          " console-setup/modelcode=pc105<wait>",
-          " debconf/frontend=noninteractive<wait>",
-          " debian-installer=en_US<wait>",
-          " fb=false<wait>",
-          " initrd=/install/initrd.gz<wait>",
-          " kbd-chooser/method=us<wait>",
-          " keyboard-configuration/layout=USA<wait>",
-          " keyboard-configuration/variant=USA<wait>",
-          " locale=en_US<wait>",
-          " netcfg/get_domain=vm<wait>",
-          " netcfg/get_hostname=vagrant<wait>",
-          " noapic<wait>",
-          " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
-          " -- <wait>",
-          "<enter><wait>"
-        ],
-        "boot_wait": "10s",
-        "headless": false,
-        "disk_size": 10140,
-        "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-        "guest_os_type": "Ubuntu_64",
-        "http_directory": "http",
-        "iso_checksum": "b17d7c1e9d0321ad5810ba77b69aef43f0f29a5422b08120e6ee0576c4527c0e",
-        "iso_checksum_type": "sha256",
-        "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
-        "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-        "ssh_password": "vagrant",
-        "ssh_port": 22,
-        "ssh_username": "vagrant",
-        "ssh_wait_timeout": "10000s",
-        "vm_name": "{{ user `PACKER_BOX_NAME` }}",
-        "vboxmanage": [
-          ["modifyvm", "{{.Name}}", "--memory", "1024"],
-          ["modifyvm", "{{.Name}}", "--cpus", "2"]
-        ],
-        "virtualbox_version_file": ".vbox_version"
-      },
-      {
-        "type": "amazon-ebs",
-        "access_key": "{{ user `AWS_ACCESS_KEY_ID` }}",
-        "secret_key": "{{ user `AWS_SECRET_ACCESS_KEY` }}",
-        "region": "us-east-1",
-        "source_ami": "ami-10b68a78",
-        "instance_type": "t1.micro",
-        "ssh_username": "ubuntu",
-        "ami_name": "packer-app-server {{timestamp}}"
-      },
-      {
-        "type": "googlecompute",
-        "account_file": "account.json",
-        "project_id": "devops-intro-project",
-        "source_image": "ubuntu-1404-trusty-v20150316",
-        "zone": "us-central1-a",
-        "image_name": "application-ubuntu-1404-{{timestamp}}",
-        "machine_type": "n1-standard-1",
-        "ssh_username": "ubuntu"
-      },
-      {
-        "type": "digitalocean",
-        "api_token": "{{ user `DIGITALOCEAN_API_TOKEN` }}",
-        "image": "ubuntu-14-04-x64",
-        "region": "tor1",
-        "size": "512mb",
-        "droplet_name": "udacity-devops",
-        "private_networking": true
-      }
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{ user `AWS_ACCESS_KEY_ID` }}",
+      "secret_key": "{{ user `AWS_SECRET_ACCESS_KEY` }}",
+      "region": "us-east-1",
+      "source_ami": "ami-10b68a78",
+      "instance_type": "t1.micro",
+      "ssh_username": "ubuntu",
+      "ami_name": "packer-app-server {{timestamp}}"
+    },
+    {
+      "type": "googlecompute",
+      "account_file": "account.json",
+      "project_id": "devops-intro-project",
+      "source_image": "ubuntu-1404-trusty-v20150316",
+      "zone": "us-central1-a",
+      "image_name": "application-ubuntu-1404-{{timestamp}}",
+      "machine_type": "n1-standard-1",
+      "ssh_username": "ubuntu"
+    },
+    {
+      "type": "digitalocean",
+      "api_token": "{{ user `DIGITALOCEAN_API_TOKEN` }}",
+      "image": "ubuntu-14-04-x64",
+      "region": "tor1",
+      "size": "512mb",
+      "droplet_name": "udacity-devops",
+      "private_networking": true
+    }
   ],
 
-  "provisioners": [
-    {
+  "provisioners": [{
       "type": "shell",
       "execute_command": "echo 'vagrant'|{{.Vars}} sudo -S -E bash '{{.Path}}'",
       "scripts": [
@@ -94,10 +92,10 @@
       ]
     },
     {
-    "type": "shell",
-    "only": ["virtualbox-iso"],
-    "execute_command": "echo 'vagrant'|sudo -S -E bash '{{.Path}}'",
-    "scripts": [
+      "type": "shell",
+      "only": ["virtualbox-iso"],
+      "execute_command": "echo 'vagrant'|sudo -S -E bash '{{.Path}}'",
+      "scripts": [
         "scripts/virtualbox.sh",
         "scripts/vagrant.sh"
       ]
@@ -112,13 +110,11 @@
     }
   ],
   "post-processors": [
-    [
-      {
-        "type": "vagrant",
-        "except": ["googlecompute", "digitalocean"],
-        "compression_level": "9",
-        "output": "{{.Provider}}/{{ user `PACKER_BOX_NAME` }}-appserver_{{.Provider}}.box"
-      }
-    ]
+    [{
+      "type": "vagrant",
+      "except": ["googlecompute", "digitalocean"],
+      "compression_level": "9",
+      "output": "{{.Provider}}/{{ user `PACKER_BOX_NAME` }}-appserver_{{.Provider}}.box"
+    }]
   ]
 }

--- a/packer-templates/control-server.json
+++ b/packer-templates/control-server.json
@@ -47,7 +47,6 @@
         "ssh_port": 22,
         "ssh_username": "vagrant",
         "ssh_wait_timeout": "10000s",
-        "type": "virtualbox-iso",
         "vm_name": "control-{{ user `PACKER_BOX_NAME` }}",
         "vboxmanage": [
           ["modifyvm", "{{.Name}}", "--memory", "1024"],

--- a/packer-templates/control-server.json
+++ b/packer-templates/control-server.json
@@ -57,9 +57,9 @@
       "type": "amazon-ebs",
       "access_key": "{{ user `AWS_ACCESS_KEY_ID` }}",
       "secret_key": "{{ user `AWS_SECRET_ACCESS_KEY` }}",
-      "region": "us-east-1",
-      "source_ami": "ami-10b68a78",
-      "instance_type": "t1.micro",
+      "region": "us-east-2",
+      "source_ami": "ami-05c1fa8df71875112",
+      "instance_type": "t2.micro",
       "ssh_username": "ubuntu",
       "ami_name": "control-{{ user `PACKER_BOX_NAME` }}-{{timestamp}}"
     },

--- a/packer-templates/control-server.json
+++ b/packer-templates/control-server.json
@@ -1,80 +1,79 @@
 {
   "variables": {
-      "PACKER_OS_FLAVOUR": "ubuntu",
-      "PACKER_BOX_NAME": "ubuntu-14.04.6-server-amd64",
-      "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
-      "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
-      "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
+    "PACKER_OS_FLAVOUR": "ubuntu",
+    "PACKER_BOX_NAME": "ubuntu-14.04.6-server-amd64",
+    "AWS_ACCESS_KEY_ID": "{{env `AWS_ACCESS_KEY_ID`}}",
+    "AWS_SECRET_ACCESS_KEY": "{{env `AWS_SECRET_ACCESS_KEY`}}",
+    "DIGITALOCEAN_API_TOKEN": "{{env `DIGITALOCEAN_API_TOKEN`}}"
   },
-  "builders": [
-      {
-        "type": "virtualbox-iso",
-        "boot_command": [
-          "<esc><wait>",
-          "<esc><wait>",
-          "<enter><wait>",
-          "/install/vmlinuz<wait>",
-          " auto<wait>",
-          " console-setup/ask_detect=false<wait>",
-          " console-setup/layoutcode=us<wait>",
-          " console-setup/modelcode=pc105<wait>",
-          " debconf/frontend=noninteractive<wait>",
-          " debian-installer=en_US<wait>",
-          " fb=false<wait>",
-          " initrd=/install/initrd.gz<wait>",
-          " kbd-chooser/method=us<wait>",
-          " keyboard-configuration/layout=USA<wait>",
-          " keyboard-configuration/variant=USA<wait>",
-          " locale=en_US<wait>",
-          " netcfg/get_domain=vm<wait>",
-          " netcfg/get_hostname=vagrant<wait>",
-          " noapic<wait>",
-          " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
-          " -- <wait>",
-          "<enter><wait>"
-        ],
-        "boot_wait": "10s",
-        "headless": false,
-        "disk_size": 10140,
-        "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
-        "guest_os_type": "Ubuntu_64",
-        "http_directory": "http",
-        "iso_checksum": "b17d7c1e9d0321ad5810ba77b69aef43f0f29a5422b08120e6ee0576c4527c0e",
-        "iso_checksum_type": "sha256",
-        "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
-        "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
-        "ssh_password": "vagrant",
-        "ssh_port": 22,
-        "ssh_username": "vagrant",
-        "ssh_wait_timeout": "10000s",
-        "vm_name": "control-{{ user `PACKER_BOX_NAME` }}",
-        "vboxmanage": [
-          ["modifyvm", "{{.Name}}", "--memory", "1024"],
-          ["modifyvm", "{{.Name}}", "--cpus", "2"]
-        ],
-        "virtualbox_version_file": ".vbox_version"
-      },
-      {
-        "type": "amazon-ebs",
-        "access_key": "{{ user `AWS_ACCESS_KEY_ID` }}",
-        "secret_key": "{{ user `AWS_SECRET_ACCESS_KEY` }}",
-        "region": "us-east-1",
-        "source_ami": "ami-10b68a78",
-        "instance_type": "t1.micro",
-        "ssh_username": "ubuntu",
-        "ami_name": "control-{{ user `PACKER_BOX_NAME` }}-{{timestamp}}"
-      },
-      {
-        "type": "googlecompute",
-        "account_file": "account.json",
-        "project_id": "devops-intro-project",
-        "source_image": "ubuntu-1404-trusty-v20150316",
-        "zone": "us-central1-a",
-        "image_name": "control-ubuntu-1404-{{timestamp}}",
-        "machine_type": "n1-standard-1",
-        "ssh_username": "ubuntu"
-      },
-      {
+  "builders": [{
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "<esc><wait>",
+        "<esc><wait>",
+        "<enter><wait>",
+        "/install/vmlinuz<wait>",
+        " auto<wait>",
+        " console-setup/ask_detect=false<wait>",
+        " console-setup/layoutcode=us<wait>",
+        " console-setup/modelcode=pc105<wait>",
+        " debconf/frontend=noninteractive<wait>",
+        " debian-installer=en_US<wait>",
+        " fb=false<wait>",
+        " initrd=/install/initrd.gz<wait>",
+        " kbd-chooser/method=us<wait>",
+        " keyboard-configuration/layout=USA<wait>",
+        " keyboard-configuration/variant=USA<wait>",
+        " locale=en_US<wait>",
+        " netcfg/get_domain=vm<wait>",
+        " netcfg/get_hostname=vagrant<wait>",
+        " noapic<wait>",
+        " preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg<wait>",
+        " -- <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "headless": false,
+      "disk_size": 10140,
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "guest_os_type": "Ubuntu_64",
+      "http_directory": "http",
+      "iso_checksum": "b17d7c1e9d0321ad5810ba77b69aef43f0f29a5422b08120e6ee0576c4527c0e",
+      "iso_checksum_type": "sha256",
+      "iso_url": "http://releases.ubuntu.com/trusty/{{ user `PACKER_BOX_NAME` }}.iso",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_username": "vagrant",
+      "ssh_wait_timeout": "10000s",
+      "vm_name": "control-{{ user `PACKER_BOX_NAME` }}",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--memory", "1024"],
+        ["modifyvm", "{{.Name}}", "--cpus", "2"]
+      ],
+      "virtualbox_version_file": ".vbox_version"
+    },
+    {
+      "type": "amazon-ebs",
+      "access_key": "{{ user `AWS_ACCESS_KEY_ID` }}",
+      "secret_key": "{{ user `AWS_SECRET_ACCESS_KEY` }}",
+      "region": "us-east-1",
+      "source_ami": "ami-10b68a78",
+      "instance_type": "t1.micro",
+      "ssh_username": "ubuntu",
+      "ami_name": "control-{{ user `PACKER_BOX_NAME` }}-{{timestamp}}"
+    },
+    {
+      "type": "googlecompute",
+      "account_file": "account.json",
+      "project_id": "devops-intro-project",
+      "source_image": "ubuntu-1404-trusty-v20150316",
+      "zone": "us-central1-a",
+      "image_name": "control-ubuntu-1404-{{timestamp}}",
+      "machine_type": "n1-standard-1",
+      "ssh_username": "ubuntu"
+    },
+    {
       "type": "digitalocean",
       "api_token": "{{ user `DIGITALOCEAN_API_TOKEN` }}",
       "image": "ubuntu-14-04-x64",
@@ -84,8 +83,7 @@
       "private_networking": true
     }
   ],
-  "provisioners": [
-    {
+  "provisioners": [{
       "type": "shell",
       "execute_command": "echo 'vagrant'|sudo -S -E bash '{{.Path}}'",
       "scripts": [
@@ -93,13 +91,13 @@
       ]
     },
     {
-    "type": "shell",
-    "only": ["virtualbox-iso"],
-    "execute_command": "echo 'vagrant'|sudo -S -E bash '{{.Path}}'",
-    "scripts": [
-    "scripts/virtualbox.sh",
-    "scripts/vagrant.sh"
-    ]
+      "type": "shell",
+      "only": ["virtualbox-iso"],
+      "execute_command": "echo 'vagrant'|sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "scripts/virtualbox.sh",
+        "scripts/vagrant.sh"
+      ]
     },
     {
       "type": "file",
@@ -118,13 +116,11 @@
     }
   ],
   "post-processors": [
-    [
-      {
-        "type": "vagrant",
-        "except": ["googlecompute", "digitalocean"],
-        "compression_level": "9",
-        "output": "../output/{{.Provider}}/control-{{ user `PACKER_BOX_NAME` }}.box"
-      }
-    ]
+    [{
+      "type": "vagrant",
+      "except": ["googlecompute", "digitalocean"],
+      "compression_level": "9",
+      "output": "../output/{{.Provider}}/control-{{ user `PACKER_BOX_NAME` }}.box"
+    }]
   ]
 }

--- a/packer-templates/scripts/graphite.sh
+++ b/packer-templates/scripts/graphite.sh
@@ -3,7 +3,7 @@
 apt-get -y install uwsgi-plugin-python uwsgi
 
 # reqs for Graphite
-apt-get -y install python-dev
+apt-get -y install python-dev libcairo2-dev libffi-dev build-essential
 apt-get -y install python-django python-django-tagging python-cairo
 apt-get -y install python-pip
 pip install pytz


### PR DESCRIPTION
Here the type is repeated in both files `application-server.json` and `control-server.json`
```
  "builders": [{
      "type": "virtualbox-iso",
.
.
.
```