### PR TITLE
chore: remove duplicate attribute type under builders

### DIFF
--- a/packer-templates/application-server.json
+++ b/packer-templates/application-server.json
@@ -47,7 +47,6 @@
         "ssh_port": 22,
         "ssh_username": "vagrant",
         "ssh_wait_timeout": "10000s",
-        "type": "virtualbox-iso",
         "vm_name": "{{ user `PACKER_BOX_NAME` }}",
         "vboxmanage": [
           ["modifyvm", "{{.Name}}", "--memory", "1024"],

--- a/packer-templates/control-server.json
+++ b/packer-templates/control-server.json
@@ -47,7 +47,6 @@
         "ssh_port": 22,
         "ssh_username": "vagrant",
         "ssh_wait_timeout": "10000s",
-        "type": "virtualbox-iso",
         "vm_name": "control-{{ user `PACKER_BOX_NAME` }}",
         "vboxmanage": [
           ["modifyvm", "{{.Name}}", "--memory", "1024"],


### PR DESCRIPTION
Here the type is repeated in both files `application-server.json` and `control-server.json`
```
  "builders": [{
      "type": "virtualbox-iso",
.
.
.
```