### PR TITLE
Bug fixed----"Vagrant up not working "

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Build 'virtualbox-iso' errored: ISO download failed.
 
 * Run `cd virtualbox`
 * Run `vagrant box add ubuntu-14.04.6-server-amd64-appserver_virtualbox.box --name devops-appserver`
+* Run `vagrant init ubuntu/focal64'
 * Run `vagrant up`
 * Run `vagrant ssh` to connect to the server
 


### PR DESCRIPTION
I added the vagrant init ubuntu/focal64 command to the README.md which was missing . 